### PR TITLE
Added possibility to process PayPal Express orders

### DIFF
--- a/app/code/community/Bubble/StockMovements/Model/Stock/Observer.php
+++ b/app/code/community/Bubble/StockMovements/Model/Stock/Observer.php
@@ -144,7 +144,7 @@ class Bubble_StockMovements_Model_Stock_Observer
     public function saveStockItemAfter($observer)
     {
         $stockItem = $observer->getEvent()->getItem();
-        if (!$stockItem->getStockStatusChangedAutomaticallyFlag() || $stockItem->getOriginalInventoryQty() != $stockItem->getQty()) {
+        if (!$stockItem->getStockStatusChangedAutomaticallyFlag() || $stockItem->getOriginalInventoryQty() !== $stockItem->getQty()) {
             if (!$message = $stockItem->getSaveMovementMessage()) {
                 if (Mage::getSingleton('api/session')->getSessionId()) {
                     $message = 'Stock saved from Magento API';

--- a/app/code/community/Bubble/StockMovements/controllers/ExpressController.php
+++ b/app/code/community/Bubble/StockMovements/controllers/ExpressController.php
@@ -7,7 +7,8 @@ class Bubble_StockMovements_ExpressController extends Mage_Paypal_ExpressControl
     public function placeOrderAction()
     {
         parent::placeOrderAction();
-        if ($this->_checkout instanceof Varien_Object && $this->_quote instanceof Mage_Sales_Model_Quote
+        if ($this->_checkout instanceof Mage_Paypal_Model_Express_Checkout
+            && $this->_quote instanceof Mage_Sales_Model_Quote
             && $this->_checkout->getOrder() instanceof Mage_Sales_Model_Order) {
             Mage::dispatchEvent(
                 'bubble_stockmovements_paypal_express_checkout_submit_all_after',

--- a/app/code/community/Bubble/StockMovements/controllers/ExpressController.php
+++ b/app/code/community/Bubble/StockMovements/controllers/ExpressController.php
@@ -1,0 +1,17 @@
+<?php
+
+require_once Mage::getModuleDir('controllers', 'Mage_PayPal') . DS . 'ExpressController.php';
+
+class Bubble_StockMovements_ExpressController extends Mage_Paypal_ExpressController
+{
+    public function placeOrderAction()
+    {
+        parent::placeOrderAction();
+        if ($this->_checkout instanceof Varien_Object && $this->_quote instanceof Mage_Sales_Model_Quote
+            && $this->_checkout->getOrder() instanceof Mage_Sales_Model_Order) {
+            Mage::dispatchEvent(
+                'bubble_stockmovements_paypal_express_checkout_submit_all_after',
+                ['order' => $this->_checkout->getOrder(), 'quote' => $this->_quote]);
+        }
+    }
+}

--- a/app/code/community/Bubble/StockMovements/controllers/ExpressController.php
+++ b/app/code/community/Bubble/StockMovements/controllers/ExpressController.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once Mage::getModuleDir('controllers', 'Mage_PayPal') . DS . 'ExpressController.php';
+require_once Mage::getModuleDir('controllers', 'Mage_Paypal') . DS . 'ExpressController.php';
 
 class Bubble_StockMovements_ExpressController extends Mage_Paypal_ExpressController
 {

--- a/app/code/community/Bubble/StockMovements/etc/config.xml
+++ b/app/code/community/Bubble/StockMovements/etc/config.xml
@@ -93,6 +93,14 @@
                     </bubble_stockmovements>
                 </observers>
             </sales_order_item_cancel>
+            <bubble_stockmovements_paypal_express_checkout_submit_all_after>
+                <observers>
+                    <bubble_stockmovements>
+                        <class>bubble_stockmovements/stock_observer</class>
+                        <method>checkoutAllSubmitAfter</method>
+                    </bubble_stockmovements>
+                </observers>
+            </bubble_stockmovements_paypal_express_checkout_submit_all_after>
         </events>
     </global>
     <adminhtml>
@@ -117,4 +125,15 @@
             </adminhtml>
         </routers>
     </admin>
+    <frontend>
+        <routers>
+            <paypal>
+                <args>
+                    <modules>
+                        <bubble_stockmovements before="Mage_Paypal">Bubble_StockMovements</bubble_stockmovements>
+                    </modules>
+                </args>
+            </paypal>
+        </routers>
+    </frontend>
 </config>


### PR DESCRIPTION
This commit adds the possibility to also process PayPal Express orders, as these do not throw the event checkout_submit_all_after.